### PR TITLE
Fixing error in phpunit test.

### DIFF
--- a/version.php
+++ b/version.php
@@ -6,7 +6,7 @@ defined("MOODLE_INTERNAL") || die();
 if (!isset($CFG)) {
     global $CFG;
 }
-if (isset($CFG) && $CFG->version >= 2014051200) {
+if (isset($CFG) && isset($CFG->version) && $CFG->version >= 2014051200) {
     if (!isset($plugin)) {
         $plugin = new stdClass();
     }


### PR DESCRIPTION
When running `php admin/tool/phpunit/cli/init.php`, I got this error:
```
PHP Notice:  Undefined property: stdClass::$version in /var/www/html/mod/respondusws/version.php on line 9

Notice: Undefined property: stdClass::$version in /var/www/html/mod/respondusws/version.php on line 9

PHPUnit test environment setup complete.
```